### PR TITLE
Properly map cohort properties

### DIFF
--- a/.clasp.json
+++ b/.clasp.json
@@ -1,5 +1,5 @@
 {
 	"scriptId": "1-e_9mTJFnWHvceBDod0OEkYP7B7fgfcxTYqggyoZGLyWOCfWvFge3hZO",
-	"rootDir": "/Users/ak/code/sheets-mixpanel",
+	"rootDir": "/Users/jakewymer/sheets",
 	"projectId": "mixpanel-gtm-training"
 }

--- a/.clasp.json
+++ b/.clasp.json
@@ -1,5 +1,5 @@
 {
 	"scriptId": "1-e_9mTJFnWHvceBDod0OEkYP7B7fgfcxTYqggyoZGLyWOCfWvFge3hZO",
-	"rootDir": "/Users/jakewymer/sheets",
+	"rootDir": "/Users/ak/code/sheets-mixpanel",
 	"projectId": "mixpanel-gtm-training"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ creds.json
 !tmp/.gitkeep
 .env
 env.js
+env.gs

--- a/Code.js
+++ b/Code.js
@@ -11,7 +11,7 @@
 -----------------------------
 */
 
-const APP_VERSION = "1.15";
+const APP_VERSION = "1.16";
 
 /**
  * some important things to know about google apps script

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 connect your google sheet with mixpanel! no coding required!
 
 [Install Now!](https://workspace.google.com/marketplace/app/sheets_%E2%87%94_mixpanel/1078767167468)
+See sample data [here](https://docs.google.com/spreadsheets/d/1-9ifFSMDk4DUrNHyUgl0L-aIxxVjno5dPkJReu0E-nk/edit?usp=sharing)
 
 <div id="tldr"></div>
 

--- a/components/dataExport.js
+++ b/components/dataExport.js
@@ -8,7 +8,7 @@ DATA OUT OF MP
  * export data; if not called with a config, uses last known
  *
  * @param  {MpSheetConfig} [config]
- * @returns {[string, ReportMeta | CohortMeta | DashMeta]} string + metadata `[csv, {}]`
+ * @returns {[string | string[][], ReportMeta | CohortMeta | DashMeta]} string + metadata `[csv, {}]`
  */
 function exportData(config) {
     //use last known config if unset
@@ -33,7 +33,7 @@ function exportData(config) {
         try {
             const meta = getCohortMeta(config);
             const profiles = getCohort(config);
-            const csv = JSONtoCSV(profiles);
+            const csv = profilesToCsvArray(profiles);
             return [csv, meta];
         } catch (e) {
             throw e;
@@ -65,6 +65,7 @@ function exportData(config) {
 
     throw `${type} is unsupported`;
 }
+
 /**
  * @param  {MpSheetConfig} config
  * @returns {DashMeta}
@@ -394,5 +395,5 @@ if (typeof module !== "undefined") {
     module.exports = { exportData };
     const { getConfig } = require("../utilities/storage.js");
     const { validateCreds } = require("../utilities/validate.js");
-    const { JSONtoCSV } = require("../utilities/misc.js");
+    const { JSONtoCSV, profilesToCsvArray } = require("../utilities/misc.js");
 }

--- a/env-sample.js
+++ b/env-sample.js
@@ -119,6 +119,23 @@ const TEST_CONFIG_GROUPS_DATA = [
     }
 ];
 
+/** @type {SheetMpConfigAlways & EventMappings} */
+const TEST_CONFIG_AD_SPENT = {
+    config_type: "sheet-to-mixpanel",
+    record_type: "event",
+    event_name_col: "hardcode",
+	hardcode_event_name: "ad spent",
+    distinct_id_col: "",
+    time_col: "timestamp",
+    insert_id_col: "campaign id",
+    project_id: PROJECT_ID,
+    token: TOKEN,
+    region: "US",
+    auth_type: "service_account",
+    service_acct: SERVICE_ACCOUNT,
+    service_secret: SERVICE_SECRET
+};
+
 /** @type {SheetMpConfigAlways & TableMappings} */
 const TEST_CONFIG_TABLES = {
     config_type: "sheet-to-mixpanel",

--- a/tests/all.test.js
+++ b/tests/all.test.js
@@ -52,6 +52,15 @@ function runTests() {
         return Misc.JSONtoCSV([{ foo: "bar", baz: "qux" }]) === expected;
     });
 
+    test.assert("turns profiles into string[][]", () => {
+        const expected = [
+            [`foo`, `baz`, `third`],
+            [`bar`, `qux`, ``],
+            [`bar`, ``, `exists`]
+        ];
+        return JSON.stringify(Misc.profilesToCsvArray([{ foo: "bar", baz: "qux" }, {foo: "bar", third: "exists"}])) === JSON.stringify(expected);
+    });
+
     test.assert("forms pretty dates?", () => {
         const expected = `3/3/1901 @ 4:20am`;
         return Misc.formatDate(new Date(1, 2, 3, 4, 20)) === expected;
@@ -218,7 +227,7 @@ function runTests() {
         validateCreds(BAD_API_SECRET);
     });
 
-    test.catchErr("THROWS: bad api project?", `Mismatch between project secret's project ID and URL project ID`, () => {
+    test.catchErr("THROWS: bad api project?", `Credentials in request did not match project_id URL parameter`, () => {
         validateCreds(BAD_PROJECT_API_SECRET);
     });
 

--- a/tests/all.test.js
+++ b/tests/all.test.js
@@ -55,10 +55,10 @@ function runTests() {
     test.assert("turns profiles into string[][]", () => {
         const expected = [
             [`foo`, `baz`, `third`],
-            [`bar`, `qux`, ``],
+            [`bar`, `qu,x`, ``],
             [`bar`, ``, `exists`]
         ];
-        return JSON.stringify(Misc.profilesToCsvArray([{ foo: "bar", baz: "qux" }, {foo: "bar", third: "exists"}])) === JSON.stringify(expected);
+        return JSON.stringify(Misc.profilesToCsvArray([{ foo: "bar", baz: "qu,x" }, {foo: "bar", third: "exists"}])) === JSON.stringify(expected);
     });
 
     test.assert("forms pretty dates?", () => {

--- a/utilities/misc.js
+++ b/utilities/misc.js
@@ -21,8 +21,6 @@ function JSONtoCSV(arr) {
 }
 
 /**
- * export data; if not called with a config, uses last known
- *
  * @param  {ProfileData[]} profiles
  * @returns {string[][]}
  */

--- a/utilities/misc.js
+++ b/utilities/misc.js
@@ -20,6 +20,12 @@ function JSONtoCSV(arr) {
         .join("\n");
 }
 
+/**
+ * export data; if not called with a config, uses last known
+ *
+ * @param  {ProfileData[]} profiles
+ * @returns {string[][]}
+ */
 function profilesToCsvArray(profiles) {
     const headers = new Set();
     

--- a/utilities/misc.js
+++ b/utilities/misc.js
@@ -20,6 +20,31 @@ function JSONtoCSV(arr) {
         .join("\n");
 }
 
+function profilesToCsvArray(profiles) {
+    const headers = new Set();
+    
+    // Need to check all profile keys in case some are missing that prop
+    profiles.forEach(profile => {
+        Object.keys(profile).forEach(key => {
+            headers.add(key);
+        });
+    });
+
+    const headersArr = Array.from(headers);
+
+    const properties = [];
+
+    profiles.forEach(profile => {
+        const profileProps = headersArr.map(header => {
+            const prop = profile[header] !== undefined ? `${profile[header]}` : "";
+            return prop;
+        });
+        properties.push(profileProps);
+    })
+
+    return [headersArr, ...properties];
+}
+
 function sliceIntoChunks(arr, chunkSize = 2000) {
     const res = [];
     for (let i = 0; i < arr.length; i += chunkSize) {
@@ -105,5 +130,5 @@ function isObject(object) {
 }
 
 if (typeof module !== "undefined") {
-    module.exports = { comma, JSONtoCSV, sliceIntoChunks, formatDate, serial, isDeepEqual, isObject, clone };
+    module.exports = { comma, JSONtoCSV, sliceIntoChunks, formatDate, serial, isDeepEqual, isObject, clone, profilesToCsvArray };
 }

--- a/utilities/sheet.js
+++ b/utilities/sheet.js
@@ -108,12 +108,12 @@ function getEmptyRow(sheet) {
 /**
  * overwrites the contents of a spreadsheet with new data
  *
- * @param  {string} csvString
+ * @param  {string | string[][]} csv
  * @param  {GoogleAppsScript.Spreadsheet.Sheet} sheet
  * @returns {SheetInfo}
  */
-function overwriteSheet(csvString, sheet) {
-    var csvData = Utilities.parseCsv(csvString);
+function overwriteSheet(csv, sheet) {
+    const csvData = typeof csv === `string` ? Utilities.parseCsv(csv) : csv;
     sheet.getRange(1, 1, csvData.length, csvData[0].length).setValues(csvData);
     return getSheetInfo(sheet);
 }


### PR DESCRIPTION
We were missing some property keys when mapping profiles to a csv array format. This also bypasses the stringify -> destringify step for cohorts as they don't need to be stringified in the first place. We could do more refactoring here, but in the interest of time, we're just sending cohorts through a different flow than the other exports as they seem to be working ok. Also fixes a test.