### PR TITLE
Route all Query API requests to Insights for client parity

### DIFF
--- a/components/dataExport.js
+++ b/components/dataExport.js
@@ -178,12 +178,12 @@ function getReportCSV(report_type, params, config) {
         throw `${report_type || "your supplied"} report is not currently supported for CSV export`;
     }
 
-    let route = report_type;
-    if (report_type === "funnels") {
-        route = `arb_funnels`;
-    }
-
-    const URL = `https://${subdomain}mixpanel.com/api/query/${route}?workspace_id=${Number(
+	// Only multi-metric bookmarks are supported with the Sheets integration.
+	// Flows reports do not suppport CSV exports.
+	// Ancient non-migrated bookmarks will not work because we route all requests through insight
+	// for parity with the client experience. If a customer with a very old report runs into issues,
+	// make a small update in the UX and save it to migrate the bookmark.
+    const URL = `https://${subdomain}mixpanel.com/api/query/insights?workspace_id=${Number(
         workspace_id
     )}&project_id=${Number(project_id)}`;
     const payload = {


### PR DESCRIPTION
Funnels and Retention bookmarks created or edited within the past 3 years all follow the multi-metric Insights format that is not fully compatible with the legacy `arb_funnels` and `retention` endpoints. All requests should be routed to Insights to ensure query parity with the UX.

https://mixpanel.atlassian.net/browse/SRFE-7220