### PR TITLE
fix(security): scope creds per-user + close DOM XSS (SECOPS-1366)

### DIFF
--- a/ui/mixpanel-to-sheet.html
+++ b/ui/mixpanel-to-sheet.html
@@ -12,15 +12,12 @@
 
 <body>
 	<!-- DATA FROM SERVER -->
-	<div id="config" class="hidden">
-		<?= JSON.stringify(config) ?>
-	</div>
-	<div id="sheet_info" class="hidden">
-		<?= JSON.stringify(sheet) ?>
-	</div>
-	<div id="sync_info" class="hidden">
-		<?= JSON.stringify(syncs) ?>
-	</div>
+	<!-- Carried in <script type="application/json"> read via .textContent (SECOPS-1366).
+	     Force-print scriptlet <?!= ?> emits raw JSON; '<' -> < keeps a '</script>'
+	     breakout impossible and JSON.parse decodes it back to '<'. -->
+	<script type="application/json" id="config" class="hidden"><?!= JSON.stringify(config).replace(/</g, "\\u003c") ?></script>
+	<script type="application/json" id="sheet_info" class="hidden"><?!= JSON.stringify(sheet).replace(/</g, "\\u003c") ?></script>
+	<script type="application/json" id="sync_info" class="hidden"><?!= JSON.stringify(syncs).replace(/</g, "\\u003c") ?></script>
 
 	<!-- ACTUAL UI -->
 	<div id="sync_notification" class="hidden">
@@ -681,7 +678,7 @@
 
 		function parseServerData(node) {
 			try {
-				return JSON.parse(node.innerText);
+				return JSON.parse(node.textContent);
 			}
 			catch (e) {
 				return {};

--- a/ui/sheet-to-mixpanel.html
+++ b/ui/sheet-to-mixpanel.html
@@ -11,18 +11,15 @@
 
 <body>
 	<!-- DATA FROM SERVER -->
-	<div id="columns" class="hidden">
-		<?= columns.toString() ?>
-	</div>
-	<div id="config" class="hidden">
-		<?= JSON.stringify(config) ?>
-	</div>
-	<div id="sheet_info" class="hidden">
-		<?= JSON.stringify(sheet) ?>
-	</div>
-	<div id="sync_info" class="hidden">
-		<?= JSON.stringify(syncs) ?>
-	</div>
+	<!-- Carried in <script type="application/json"> read via .textContent (SECOPS-1366).
+	     Use the force-print scriptlet <?!= ?> (NOT <?= ?>): inside a raw-text <script> element
+	     the HTML parser does not decode entities, so HTML-escaped output would not JSON.parse.
+	     We instead emit raw JSON and escape '<' -> <, which JSON.parse decodes back to '<'
+	     while making a '</script>' breakout impossible. -->
+	<script type="application/json" id="columns" class="hidden"><?!= columns.toString().replace(/</g, "\\u003c") ?></script>
+	<script type="application/json" id="config" class="hidden"><?!= JSON.stringify(config).replace(/</g, "\\u003c") ?></script>
+	<script type="application/json" id="sheet_info" class="hidden"><?!= JSON.stringify(sheet).replace(/</g, "\\u003c") ?></script>
+	<script type="application/json" id="sync_info" class="hidden"><?!= JSON.stringify(syncs).replace(/</g, "\\u003c") ?></script>
 
 	<!-- ACTUAL UI -->
 	<div id="sync_notification" class="hidden">
@@ -571,7 +568,7 @@
 				syncSheetLabel: qs('#sync_notification_sheet'),
 
 				//parsed server templates
-				columns: qs('#columns').innerText.split(',').map(str => str.trim()),
+				columns: qs('#columns').textContent.split(',').map(str => str.trim()),
 				config: this.parseServerTemplate(qs('#config')),
 				sheet: this.parseServerTemplate(qs('#sheet_info')),
 				syncInfo: this.parseServerTemplate(qs("#sync_info"))
@@ -595,14 +592,14 @@
 				for (const column of columns) {
 					const opt = document.createElement('option');
 					opt.value = column;
-					opt.innerHTML = column;
+					opt.textContent = column;
 					select.appendChild(opt);
 				}
 				if (select.parentNode.parentElement.id === "event_mapping") {
 					if (["event_name_col", "distinct_id_col"].includes(select.id)) {
 						const hardcodeOpt = document.createElement('option');
 						hardcodeOpt.value = "hardcode";
-						hardcodeOpt.innerHTML = `Other (specify)`;
+						hardcodeOpt.textContent = `Other (specify)`;
 						select.appendChild(hardcodeOpt);
 						select.addEventListener('change', (ev) => {
 							if (ev.currentTarget.value === 'hardcode') {
@@ -625,8 +622,12 @@
 		function bindEventsAndViews() {
 			// DYNAMIC VALUES
 			if (this.DOM.sheet.sheet_name) {
-				this.DOM.sheetNameLabel.innerHTML = `current sheet: <b>${this.DOM.sheet.sheet_name}</b>`;
-
+				// textContent (not innerHTML): the tab name is attacker-controllable and must
+				// never be parsed as markup (SECOPS-1366). build the <b> via DOM, not a string.
+				this.DOM.sheetNameLabel.textContent = 'current sheet: ';
+				const bold = document.createElement('b');
+				bold.textContent = this.DOM.sheet.sheet_name;
+				this.DOM.sheetNameLabel.appendChild(bold);
 			}
 
 			// TYPES + MAPPINGS
@@ -784,7 +785,7 @@
 
 		function parseServerTemplate(node) {
 			try {
-				return JSON.parse(node.innerText);
+				return JSON.parse(node.textContent);
 			}
 			catch (e) {
 				return {};

--- a/utilities/storage.js
+++ b/utilities/storage.js
@@ -10,7 +10,9 @@ STORAGE + TRIGGERS
  * @returns {SheetMpConfig | MpSheetConfig | Object}
  */
 function getConfig() {
-    const scriptProperties = PropertiesService.getDocumentProperties();
+    // user-scoped store: credentials are private to the user who saved them, so an
+    // editor opening the add-on never reads the owner's service-account secret (SECOPS-1366)
+    const scriptProperties = PropertiesService.getUserProperties();
     const props = scriptProperties.getProperties();
     return props;
 }
@@ -22,7 +24,7 @@ function getConfig() {
  * @returns {SheetMpConfig | MpSheetConfig | Object}
  */
 function setConfig(config) {
-    const scriptProperties = PropertiesService.getDocumentProperties();
+    const scriptProperties = PropertiesService.getUserProperties();
     scriptProperties.setProperties(config);
 
     // @ts-ignore
@@ -37,7 +39,7 @@ function setConfig(config) {
  * @param  {string} value
  */
 function updateConfig(key, value) {
-    const scriptProperties = PropertiesService.getDocumentProperties();
+    const scriptProperties = PropertiesService.getUserProperties();
     scriptProperties.setProperty(key, value);
     return scriptProperties.getProperties();
 }
@@ -49,7 +51,7 @@ function updateConfig(key, value) {
  * @param  {number} [limit] max # of values to store @ key
  */
 function appendConfig(key, value, limit = 50) {
-    const scriptProperties = PropertiesService.getDocumentProperties();
+    const scriptProperties = PropertiesService.getUserProperties();
     const config = scriptProperties.getProperties();
     if (config[key]) {
         const currentList = JSON.parse(config[key]);
@@ -78,7 +80,7 @@ function appendConfig(key, value, limit = 50) {
  * @returns {{}}
  */
 function clearConfig(config, deleteAll = false) {
-    const scriptProperties = PropertiesService.getDocumentProperties();
+    const scriptProperties = PropertiesService.getUserProperties();
     scriptProperties.deleteAllProperties();
     clearTriggers(config?.trigger, deleteAll);
 


### PR DESCRIPTION
## Summary

Remediates [SECOPS-1366](https://mixpanel.atlassian.net/browse/SECOPS-1366) (HackerOne report 3768019). An **Editor** of a shared spreadsheet could steal the sheet owner's long-lived Mixpanel service-account credentials. Two chained defects:

1. **Credential exposure (CWE-522)** — config (incl. `service_secret`, `auth`, `token`) was stored in **Document Properties**, a store shared by every editor, and dumped into the sidebar DOM. Any editor opening the add-on could read the owner's secret — no exploit needed.
2. **Stored DOM XSS (CWE-79)** — an attacker-controlled tab name flowed to an `innerHTML` sink; server-side `<?= ?>` escaping was defeated because the client re-decoded the value via `.innerText`. Fired on sidebar open in the owner's authorized origin and beaconed creds out.

Per-user storage alone does **not** close the XSS (the victim *is* the owner, who legitimately holds the creds), so this PR fixes both.

## Changes

- **`utilities/storage.js`** — `getDocumentProperties()` → `getUserProperties()` (5 sites). Config is now private to the user who saved it. Sync is unaffected: the hourly trigger runs as its creator and reads that user's properties, matching the already per-user `ScriptApp.getProjectTriggers()`.
- **`ui/sheet-to-mixpanel.html`** — `innerHTML` → `textContent` at the sheet-name label and option-label sinks; attacker-controlled tab names / headers can no longer parse as markup.
- **both UI files** — server data carried in `<script type="application/json">` read via `.textContent` instead of hidden `<div>` + `.innerText`, removing the HTML-entity round-trip. Raw JSON emitted via the force-print scriptlet with `<` → `<` to block a `</script>` breakout.

## Behavior change

A second editor who also installed the add-on no longer sees the owner's sync config in the sidebar (intended isolation). Each user configures their own sync under their own creds.

## Testing

- `npm run test-local` — passes (HTML/storage are GAS-gated; no regressions).
- **TODO before merge (GAS-only, can't run locally):**
  - `npm run test-server` (`clasp run runTests`) — storage save/get/clear against UserProperties.
  - Open sidebar as owner (config loads, sync runs) and as a second Editor (cred fields blank, `#config` empty).
  - XSS repro: set a malicious tab name → must render as literal text, no outbound request.

## Note

The leaked project token/secret in the report (`project_id 4019936`) should be **rotated** independently — this patch stops future theft but the exposed secret is already out.

[SECOPS-1366]: https://mixpanel.atlassian.net/browse/SECOPS-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ