### PR TITLE
feat: tag Mixpanel requests with source baggage header; drop use_query_cache

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -11,7 +11,10 @@
 -----------------------------
 */
 
-const APP_VERSION = "1.23";
+const APP_VERSION = "1.24";
+
+// added to every data-plane request so Mixpanel can attribute traffic to this add-on
+const MP_SOURCE_HEADER = { baggage: "mp.source.name=sheets-mixpanel" };
 
 /**
  * some important things to know about google apps script

--- a/components/dataExport.js
+++ b/components/dataExport.js
@@ -86,7 +86,9 @@ function enumDashboard(config) {
         method: "get",
         headers: {
             Authorization: `Basic ${auth}`,
-            Accept: "application/json"
+            Accept: "application/json",
+            // @ts-ignore
+            ...MP_SOURCE_HEADER
         },
         muteHttpExceptions: true
     };
@@ -133,7 +135,9 @@ function getParams(config) {
         method: "get",
         headers: {
             Authorization: `Basic ${auth}`,
-            Accept: "application/json"
+            Accept: "application/json",
+            // @ts-ignore
+            ...MP_SOURCE_HEADER
         },
         muteHttpExceptions: true
     };
@@ -188,7 +192,6 @@ function getReportCSV(report_type, params, config) {
     )}&project_id=${Number(project_id)}`;
     const payload = {
         bookmark: params,
-        use_query_cache: false,
         format: "csv"
     };
 
@@ -196,7 +199,9 @@ function getReportCSV(report_type, params, config) {
     const options = {
         method: "post",
         headers: {
-            Authorization: `Basic ${auth}`
+            Authorization: `Basic ${auth}`,
+            // @ts-ignore
+            ...MP_SOURCE_HEADER
         },
         muteHttpExceptions: true,
         payload: JSON.stringify(payload)
@@ -234,7 +239,9 @@ function getCohort(config) {
         method: "post",
         headers: {
             Authorization: `Basic ${auth}`,
-            "Content-Type": `application/x-www-form-urlencoded`
+            "Content-Type": `application/x-www-form-urlencoded`,
+            // @ts-ignore
+            ...MP_SOURCE_HEADER
         },
         muteHttpExceptions: true,
         payload: JSON.stringify(payload)
@@ -284,7 +291,9 @@ function getCohortMeta(config) {
         method: "post",
         headers: {
             Authorization: `Basic ${auth}`,
-            Accept: `application/json`
+            Accept: `application/json`,
+            // @ts-ignore
+            ...MP_SOURCE_HEADER
         },
         muteHttpExceptions: true
     };

--- a/utilities/flush.js
+++ b/utilities/flush.js
@@ -35,7 +35,9 @@ function flushToMixpanel(data, config, strict = 0) {
         contentType: "application/json",
         headers: {
             Authorization: `Basic ${config.auth}`,
-            Accept: "application/json"
+            Accept: "application/json",
+            // @ts-ignore
+            ...MP_SOURCE_HEADER
         },
         muteHttpExceptions: true
     };

--- a/utilities/validate.js
+++ b/utilities/validate.js
@@ -37,7 +37,9 @@ function validateCreds(config) {
             contentType: "application/json",
             headers: {
                 Authorization: `Basic ${auth}`,
-                Accept: "application/json"
+                Accept: "application/json",
+                // @ts-ignore
+                ...MP_SOURCE_HEADER
             },
             muteHttpExceptions: true,
             payload: JSON.stringify([{}]) //sending an empty event to /import will validate the credentials + project_id
@@ -74,7 +76,9 @@ function validateCreds(config) {
             method: "get",
             headers: {
                 Authorization: `Basic ${auth}`,
-                Accept: "application/json"
+                Accept: "application/json",
+                // @ts-ignore
+                ...MP_SOURCE_HEADER
             },
             muteHttpExceptions: false
         };


### PR DESCRIPTION
Small observability + cleanup PR. Three changes:

### 1. `baggage` source header on data-plane requests
Adds `baggage: mp.source.name=sheets-mixpanel` to every customer-facing Mixpanel request so Mixpanel can attribute traffic to this add-on. Implemented as a single global `MP_SOURCE_HEADER` const (next to `APP_VERSION` in `Code.js`), spread into each `headers` object — mirrors how `APP_VERSION` is a cross-file global.

Covered (8 sites, 3 files): `components/dataExport.js` (dashboard, bookmark, insights CSV, cohort engage, cohort list), `utilities/flush.js` (import/engage/groups/lookup-tables), `utilities/validate.js` (both cred-validation calls).

Intentionally **excluded**: the add-on's own usage telemetry in `utilities/tracker.js`.

context: https://mixpanel.slack.com/archives/C04N44HV4G6/p1780674844269129

### 2. Remove deprecated `use_query_cache`
Dropped from the `/api/query/insights` payload in `getReportCSV` (`components/dataExport.js`).

context: https://mixpanel.slack.com/archives/C04TJL0J0/p1781737146420789?thread_ts=1781725732.755989&cid=C04TJL0J0

### 3. Version bump
`APP_VERSION` 1.23 → 1.24.

---

### Verification
- `npm run type-check` — no new error category (pre-existing typedef noise only).
- `npm run test-local` — green (14/14).
- ⚠️ **Merge bar not yet run:** `npm run push` + `npm run test-server` (full server suite vs real Mixpanel, ~41 assertions) should be run before merge.